### PR TITLE
Add tomorrow forecast and horizontal hourly view

### DIFF
--- a/weather-app/index.html
+++ b/weather-app/index.html
@@ -15,6 +15,12 @@
             <div id="weather-afternoon" class="weather-item"></div>
             <div id="highlow"></div>
         </div>
+        <h2 id="tomorrow-title">明日の天気</h2>
+        <div id="weather-tomorrow">
+            <div id="tomorrow-morning" class="weather-item"></div>
+            <div id="tomorrow-afternoon" class="weather-item"></div>
+            <div id="tomorrow-highlow"></div>
+        </div>
         <div id="hourly"></div>
         <section id="clothing"></section>
         <section id="advice"></section>

--- a/weather-app/style.css
+++ b/weather-app/style.css
@@ -61,47 +61,43 @@ button:hover {
     font-size: 1.2rem;
 }
 
+#weather-tomorrow {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 10px;
+}
+
+#tomorrow-highlow {
+    margin-top: 10px;
+    font-size: 1.2rem;
+}
+
 #hourly {
     margin-top: 20px;
     overflow-x: auto;
 }
 
-#hourly table {
-    width: 100%;
-    border-collapse: collapse;
+#hourly .hourly-scroll {
+    display: flex;
 }
 
-#hourly th,
-#hourly td {
+#hourly .hour-item {
+    flex: 0 0 auto;
+    width: 60px;
     border: 1px solid #ccc;
-    padding: 6px 8px;
+    border-radius: 6px;
+    margin-right: 4px;
+    padding: 4px;
+    font-size: 0.9rem;
     text-align: center;
 }
 
-#hourly tbody tr:hover {
-    background: rgba(0, 0, 0, 0.05);
+#hourly .hour-item.past {
+    opacity: 0.5;
 }
 
-#hourly .emoji {
+#hourly .hour-icon {
     font-size: 1.2rem;
-}
-
-@media (max-width: 767px) {
-    #hourly th {
-        display: none;
-    }
-    #hourly tbody tr {
-        display: flex;
-        justify-content: space-between;
-        border: 1px solid #ccc;
-        border-radius: 6px;
-        padding: 6px;
-        margin-bottom: 8px;
-    }
-    #hourly tbody td {
-        border: none;
-        padding: 0 4px;
-    }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- show tomorrow's weather forecast under new heading
- redesign hourly forecast as horizontally scrollable list
- dim past hours in hourly view

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e2e7b8d488321a071a0e6f718a8b7